### PR TITLE
FIX wrong setting of wavenumbers axis

### DIFF
--- a/brukeropusreader/opus_data.py
+++ b/brukeropusreader/opus_data.py
@@ -7,8 +7,8 @@ class OpusData(dict):
         param_key = f"{spec_name} Data Parameter"
         fxv = self[param_key]["FXV"]
         lxv = self[param_key]["LXV"]
-        # NPT and REAL NUMBER OF POINTS may differ
-        npt = self[spec_name].shape[0]
+        # the number of points here is OK. It is "AB" that can return more values (equals to zero)
+        npt = self[param_key]["NPT"]
         x_no_unit = np.linspace(fxv, lxv, npt)
         if wavenums:
             return x_no_unit

--- a/example.py
+++ b/example.py
@@ -11,14 +11,17 @@ def main(path_to_file):
     print(f"Data fields: " f"{list(opus_data.keys())}")
 
     ab_x = opus_data.get_range("AB")
+    # the "AB" data can contain more null values at the end (at least 1)
+    # so the getting useful data requires slicing the array:
+    abs = opus_data["AB"][0:len(ab_x)]
     print(f"Absorption spectrum range: " f"{ab_x[0]} {ab_x[-1]}")
-    print(f"Absorption elements num: " f'{len(opus_data["AB"])}')
+    print(f"Absorption elements num: " f'{len(abs)}')
 
     try:
         import matplotlib.pyplot as plt
 
         print("Plotting AB")
-        plt.plot(opus_data.get_range("AB"), opus_data["AB"])
+        plt.plot(opus_data.get_range("AB"), abs)
         plt.show()
 
         print("Plotting interpolated AB")


### PR DESCRIPTION
The number of points of the wavenumber axis is incorrectly set, which led to a shift of spectra